### PR TITLE
Create running state

### DIFF
--- a/lib/BitbucketHandler.js
+++ b/lib/BitbucketHandler.js
@@ -264,11 +264,13 @@ BitbucketHandler.prototype.buildStatusUpdateHandler = function(update, build, cb
   self.log.info({update: update, build_id: build.id}, 'Got build status update');
 
   // maps github-like statuses to ones that bitbucket accepts
+  // https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/statuses/build
   var stateMap = {
     success: 'SUCCESSFUL',
-    pending: 'INPROGRESS',
+    pending: 'STOPPED',
     error: 'FAILED',
     fail: 'FAILED',
+    running: 'INPROGRESS',
   };
   var statusInfo = {
     state: stateMap[update.state],

--- a/lib/BitbucketHandler.js
+++ b/lib/BitbucketHandler.js
@@ -267,7 +267,7 @@ BitbucketHandler.prototype.buildStatusUpdateHandler = function(update, build, cb
   // https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/statuses/build
   var stateMap = {
     success: 'SUCCESSFUL',
-    pending: 'STOPPED',
+    pending: 'INPROGRESS',
     error: 'FAILED',
     fail: 'FAILED',
     running: 'INPROGRESS',

--- a/lib/BitbucketHandler.js
+++ b/lib/BitbucketHandler.js
@@ -285,7 +285,7 @@ BitbucketHandler.prototype.buildStatusUpdateHandler = function(update, build, cb
 
   // handle bad state
   if (!statusInfo.state) {
-    statusInfo.state = 'PENDING';
+    statusInfo.state = 'STOPPED';
     statusInfo.description = (statusInfo.description || '') + ' (original state:' + update.state + ')';
   }
 


### PR DESCRIPTION
The container manager has a "running" state as of https://github.com/ProboCI/probo/pull/98

However, Bitbucket does not accept that as a valid state. Thus, this PR remaps "running" to "INPROGRESS".

**Dependencies**
https://github.com/ProboCI/probo/pull/98

**To test**
Make some builds on Bitbucket, and ensure the correct task states are publishing.