### PR TITLE
Integrate probo-request-logger to log the requests

### DIFF
--- a/lib/BitbucketHandler.js
+++ b/lib/BitbucketHandler.js
@@ -1,16 +1,13 @@
 'use strict';
 
-var restify = require('restify');
-var bunyan = require('bunyan');
-var yaml = require('js-yaml');
-var async = require('async');
-
-var WebhookHandler = require('./bitbucketWebhookHandler');
-
-var Bitbucket = require('./bitbucket');
-
-
-var API = require('./api');
+const restify = require('restify');
+const bunyan = require('bunyan');
+const yaml = require('js-yaml');
+const async = require('async');
+const requestLogger = require('probo-request-logger');
+const WebhookHandler = require('./bitbucketWebhookHandler');
+const Bitbucket = require('./bitbucket');
+const API = require('./api');
 
 /**
  * Create a queue that only processes one task at a time.
@@ -22,6 +19,7 @@ var statusUpdateQueue = async.queue(function worker(fn, cb) {
 
 
 var BitbucketHandler = function(options) {
+  const self = this;
 
   this.options = options;
 
@@ -56,16 +54,12 @@ var BitbucketHandler = function(options) {
   handler.on('pullrequest:updated', this.pullRequestHandler);
   handler.on('repo:push', this.pushHandler);
 
-  var self = this;
-
   var server = options.server;
-
-
-  // verbatim
   if (!server) {
     server = restify.createServer({log: log, name: 'Probo Bitbucket'});
 
     // set up request logging
+    server.use(requestLogger({logger: log}));
     server.use(restify.queryParser({mapParams: false}));
 
     server.use(function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bunyan": "^1.4.0",
     "js-yaml": "^3.3.1",
     "oauth": "^0.9.14",
+    "probo-request-logger": "^1.0.1",
     "querystring": "^0.2.0",
     "request": "^2.57.0",
     "restify": "^3.0.3",


### PR DESCRIPTION
This PR integrates our enhanced [request logger](https://www.npmjs.com/package/probo-request-logger). 

Before releasing this, we probably want to update the request logger project to strip out some URL parameters from logged URLs. For example, `token=blah` or `refreshToken=blah`.