### PR TITLE
Changes that allow the open source Bitbucket plugin to work with open…

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,15 +1,16 @@
 # Port for the server to listen on
 port: 3012
-hostname: localhost
+hostname: 0.0.0.0
 
 bbWebhookUrl: '/bitbucket-webhook'
 # Bitbucket client key and client secret. These are generated for you
 # when you create a new OAuth client in Bitbucket
-# bbClientKey: null
-# bbClientSecret: null
+#bbClientKey: 
+#bbClientSecret: 
+#bbAccessToken: 
+#bbRefreshToken: 
 
 # Settings for the API or Container Manager server
 # port
 api:
-  url: "http://localhost:3000"
-  token: "token2"
+  url: "http://localhost:3020"

--- a/lib/BitbucketHandler.js
+++ b/lib/BitbucketHandler.js
@@ -143,7 +143,7 @@ var BitbucketHandler = function(options) {
 };
 
 BitbucketHandler.prototype.validateOptions = function() {
-  var required = ['bbWebhookUrl', 'bbClientKey', 'bbClientSecret'];
+  var required = ['bbWebhookUrl', 'bbClientKey', 'bbClientSecret', 'bbAccessToken', 'bbRefreshToken'];
   this._validate(this.options, required);
 };
 

--- a/lib/bitbucket/index.js
+++ b/lib/bitbucket/index.js
@@ -136,8 +136,6 @@ class Bitbucket {
       json: true,
     };
 
-
-
     request.post(opts, function(error, response, body) {
       if (error) {
         return done(error);

--- a/lib/cm_api.js
+++ b/lib/cm_api.js
@@ -72,9 +72,8 @@ CMAPI.prototype.setBuildStatus = function(build, context, status, cb) {
  * @param {function} cb - A callback to perform after the project has been found.
  */
 CMAPI.prototype.findProjectByRepo = function(request, cb) {
-  this.log.info('returning static project object');
-
   var self = this;
+
   setImmediate(function() {
     cb(null, {
       id: request.slug.replace('/', '-'),
@@ -82,8 +81,8 @@ CMAPI.prototype.findProjectByRepo = function(request, cb) {
       owner: request.owner,
       repo: request.repo,
       slug: request.slug,
-      service_auth: {token: self.handler.githubAPIToken, type: 'token'},
-      provider: {type: 'github', slug: 'github'},
+      service_auth: {token: self.handler.bbAccessToken, refreshToken: self.handler.bbRefreshToken, type: 'token'},
+      provider: {type: 'bitbucket', slug: 'bitbucket'},
     });
   });
 };


### PR DESCRIPTION
… source probo server. Readme instructions to follow.

I have added an initial API token and Refresh token you have to go through a bit of hocus pocus with Bitbucket to get before an implementation of Bitbucket will work with the open source Probo server. I could not come up with another way to get this working. I am open to thoughts on how to get this working and other ways and sincerely hope there is something better than this.